### PR TITLE
Initial Telegram bot starter: plugin loader, serializer, button manager, and sample plugins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Salin file ini menjadi .env lalu isi token bot Telegram
+TELEGRAM_BOT_TOKEN=ISI_TOKEN_BOT_KAMU_DI_SINI

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Telegram Bot Sederhana (Node.js + Auto Plugin)
+
+## Yang sudah dibikin
+- Command auto-register dari folder `plugins/`.
+- Serializer memakai **1 function utama**: `serializeTelegramUpdate(ctx, options)`.
+- Button pakai format singkat, bisa untuk message dan media.
+- Ada fitur global auto-edit pesan saat tombol diklik (`edit: true`).
+
+## Format button singkat
+Format pasangan:
+- elemen pertama = teks button
+- elemen kedua = callback
+- elemen ketiga (opsional) = opsi, contoh `{ edit: true, text: "..." }`
+
+### Kirim pesan biasa
+```js
+await ctx.sendMessage(
+  "tes",
+  ["ping", "ping"],
+  ["mantap", "mantap"]
+);
+```
+
+### Kirim media
+```js
+await ctx.sendPhoto(
+  "https://picsum.photos/300/200",
+  "caption",
+  ["ping", "ping"],
+  ["mantap", "mantap"]
+);
+```
+
+### Auto edit pesan global
+Kalau tombol punya opsi `edit: true`, bot otomatis edit pesan saat tombol itu diklik.
+
+```js
+["Edit pesan", "edit_1", { edit: true, text: "✅ Sudah di-edit" }]
+```
+
+## Struktur penting
+- `bot_telegram.js` → load plugin otomatis + callback query global + helper global (`ctx.button`, `ctx.sendMessage`, `ctx.sendPhoto`, `ctx.editpesan`)
+- `lib/serialize.js` → 1 function serializer utama
+- `lib/button-format.js` → parser format singkat button + resolver action callback
+- `plugins/*.js` → command/plugin
+
+## Jalankan
+```bash
+npm install
+export TELEGRAM_BOT_TOKEN="TOKEN_DARI_BOTFATHER"
+npm start
+```

--- a/bot_telegram.js
+++ b/bot_telegram.js
@@ -1,0 +1,94 @@
+"use strict";
+
+const { Telegraf } = require("telegraf");
+const { loadPlugins, validatePlugin } = require("./lib/plugin-loader");
+const { serializeTelegramUpdate } = require("./lib/serialize");
+const { createButtonManager } = require("./lib/button-format");
+
+function getTokenFromEnv() {
+  const token = (process.env.TELEGRAM_BOT_TOKEN || "").trim();
+
+  if (!token) {
+    throw new Error(
+      "TELEGRAM_BOT_TOKEN belum diset. Set env dulu, contoh: TELEGRAM_BOT_TOKEN=xxx"
+    );
+  }
+
+  return token;
+}
+
+function buildBot(token) {
+  const bot = new Telegraf(token);
+  const plugins = loadPlugins();
+  const buttonManager = createButtonManager();
+
+  bot.use(async (ctx, next) => {
+    ctx.button = (...pairs) => buttonManager.button(...pairs);
+    ctx.sendMessage = (text, ...pairs) => buttonManager.sendMessage(ctx, text, ...pairs);
+    ctx.sendPhoto = (photo, caption, ...pairs) =>
+      buttonManager.sendPhoto(ctx, photo, caption, ...pairs);
+    ctx.editpesan = (text, ...pairs) =>
+      ctx.editMessageText(text, pairs.length ? ctx.button(...pairs) : undefined);
+
+    return next();
+  });
+
+  for (const plugin of plugins) {
+    validatePlugin(plugin);
+
+    bot.command(plugin.name, async (ctx) => {
+      const serialized = serializeTelegramUpdate(ctx, { commandName: plugin.name });
+
+      return plugin.run({
+        ctx,
+        args: serialized.command.args,
+        serialized,
+        plugins,
+      });
+    });
+  }
+
+  // pembacaan button global + auto edit jika edit:true
+  bot.on("callback_query", async (ctx) => {
+    const action = buttonManager.resolveAction(ctx.callbackQuery?.data);
+
+    if (!action) {
+      await ctx.answerCbQuery("Button terbaca ✅");
+      return;
+    }
+
+    if (action.edit) {
+      const newText = action.editText || `Dipilih: ${action.callback}`;
+      await ctx.editpesan(newText);
+      await ctx.answerCbQuery("Pesan berhasil di-edit ✅");
+      return;
+    }
+
+    await ctx.answerCbQuery("Button terbaca ✅");
+    await ctx.reply(`Button dipilih: ${action.callback}`);
+  });
+
+  return { bot, plugins };
+}
+
+async function main() {
+  const token = getTokenFromEnv();
+  const { bot, plugins } = buildBot(token);
+
+  await bot.launch();
+  // eslint-disable-next-line no-console
+  console.log(
+    `Bot berjalan dengan ${plugins.length} command: ${plugins
+      .map((plugin) => `/${plugin.name}`)
+      .join(", ")}`
+  );
+
+  process.once("SIGINT", () => bot.stop("SIGINT"));
+  process.once("SIGTERM", () => bot.stop("SIGTERM"));
+}
+
+main().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error("Gagal menjalankan bot:", error.message);
+  process.exit(1);
+});

--- a/lib/button-format.js
+++ b/lib/button-format.js
@@ -1,0 +1,75 @@
+"use strict";
+
+function createButtonManager() {
+  const actionStore = new Map();
+  let sequence = 0;
+
+  function normalizeButtonPair(pair) {
+    if (!Array.isArray(pair) || pair.length < 2) {
+      throw new TypeError(
+        "Format button harus [label, callback] atau [label, callback, { edit: true }]"
+      );
+    }
+
+    const [label, callbackValue, options = {}] = pair;
+    const id = String(++sequence);
+
+    actionStore.set(id, {
+      callback: String(callbackValue),
+      edit: Boolean(options.edit),
+      editText:
+        typeof options.text === "string" && options.text.trim()
+          ? options.text.trim()
+          : null,
+    });
+
+    return {
+      text: String(label),
+      callback_data: `btn:${id}`,
+    };
+  }
+
+  function button(...pairs) {
+    const inline_keyboard = pairs.map((pair) => [normalizeButtonPair(pair)]);
+
+    return {
+      reply_markup: {
+        inline_keyboard,
+      },
+    };
+  }
+
+  async function sendMessage(ctx, text, ...pairs) {
+    return ctx.reply(text, button(...pairs));
+  }
+
+  async function sendPhoto(ctx, photo, caption, ...pairs) {
+    return ctx.replyWithPhoto(photo, {
+      caption,
+      ...button(...pairs),
+    });
+  }
+
+  function resolveAction(rawData) {
+    if (!rawData || !rawData.startsWith("btn:")) {
+      return null;
+    }
+
+    const id = rawData.slice(4);
+    const action = actionStore.get(id);
+    if (!action) return null;
+
+    return action;
+  }
+
+  return {
+    button,
+    sendMessage,
+    sendPhoto,
+    resolveAction,
+  };
+}
+
+module.exports = {
+  createButtonManager,
+};

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const PLUGINS_DIR = path.join(__dirname, "..", "plugins");
+
+function validatePlugin(plugin) {
+  if (!plugin || typeof plugin !== "object") {
+    throw new TypeError("Plugin harus berupa object");
+  }
+
+  if (!plugin.name || typeof plugin.name !== "string") {
+    throw new TypeError("Plugin wajib memiliki name (string)");
+  }
+
+  if (!/^[a-z0-9_]+$/i.test(plugin.name)) {
+    throw new TypeError(
+      `Nama plugin '${plugin.name}' tidak valid. Gunakan huruf/angka/underscore.`
+    );
+  }
+
+  if (!plugin.description || typeof plugin.description !== "string") {
+    throw new TypeError("Plugin wajib memiliki description (string)");
+  }
+
+  if (typeof plugin.run !== "function") {
+    throw new TypeError("Plugin wajib memiliki run (function)");
+  }
+}
+
+function loadPlugins() {
+  const files = fs
+    .readdirSync(PLUGINS_DIR)
+    .filter((file) => file.endsWith(".js"))
+    .filter((file) => !file.startsWith("_"))
+    .filter((file) => file !== "index.js")
+    .sort((a, b) => a.localeCompare(b));
+
+  const plugins = files.map((file) => {
+    const fullPath = path.join(PLUGINS_DIR, file);
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const plugin = require(fullPath);
+    validatePlugin(plugin);
+
+    return {
+      ...plugin,
+      __file: file,
+    };
+  });
+
+  const names = new Set();
+  for (const plugin of plugins) {
+    if (names.has(plugin.name)) {
+      throw new Error(
+        `Duplikat command '/${plugin.name}' terdeteksi (file: ${plugin.__file})`
+      );
+    }
+    names.add(plugin.name);
+  }
+
+  return plugins;
+}
+
+module.exports = {
+  loadPlugins,
+  validatePlugin,
+};

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -1,0 +1,284 @@
+"use strict";
+
+function serializeTelegramUpdate(ctx, options = {}) {
+  const safeDate = (value) => {
+    if (!value) return null;
+    const date = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  };
+
+  const pickDefined = (object) =>
+    Object.fromEntries(
+      Object.entries(object).filter(([, value]) => value !== undefined)
+    );
+
+  const toArray = (value) => (Array.isArray(value) ? value : []);
+
+  const serializeUser = (user) => {
+    if (!user) return null;
+    return pickDefined({
+      id: user.id,
+      isBot: user.is_bot,
+      firstName: user.first_name,
+      lastName: user.last_name,
+      username: user.username,
+      languageCode: user.language_code,
+    });
+  };
+
+  const serializeChat = (chat) => {
+    if (!chat) return null;
+    return pickDefined({
+      id: chat.id,
+      type: chat.type,
+      title: chat.title,
+      username: chat.username,
+      firstName: chat.first_name,
+      lastName: chat.last_name,
+      bio: chat.bio,
+      description: chat.description,
+      inviteLink: chat.invite_link,
+      hasProtectedContent: chat.has_protected_content,
+    });
+  };
+
+  const serializeEntities = (entities = []) =>
+    toArray(entities).map((entity) =>
+      pickDefined({
+        type: entity.type,
+        offset: entity.offset,
+        length: entity.length,
+        url: entity.url,
+        language: entity.language,
+        customEmojiId: entity.custom_emoji_id,
+        user: serializeUser(entity.user),
+      })
+    );
+
+  const serializeFileMeta = (file) => {
+    if (!file) return null;
+    return pickDefined({
+      fileId: file.file_id,
+      fileUniqueId: file.file_unique_id,
+      fileSize: file.file_size,
+      width: file.width,
+      height: file.height,
+      duration: file.duration,
+      fileName: file.file_name,
+      mimeType: file.mime_type,
+      thumbnail: serializeFileMeta(file.thumbnail),
+    });
+  };
+
+  const serializeInlineButton = (button) => {
+    if (!button) return null;
+    return pickDefined({
+      text: button.text,
+      callbackData: button.callback_data,
+      url: button.url,
+      webApp: button.web_app,
+      loginUrl: button.login_url,
+      switchInlineQuery: button.switch_inline_query,
+      switchInlineQueryCurrentChat: button.switch_inline_query_current_chat,
+      switchInlineQueryChosenChat: button.switch_inline_query_chosen_chat,
+      callbackGame: button.callback_game,
+      pay: button.pay,
+    });
+  };
+
+  const serializeKeyboardButton = (button) => {
+    if (!button) return null;
+    if (typeof button === "string") return { text: button };
+    return pickDefined({
+      text: button.text,
+      requestContact: button.request_contact,
+      requestLocation: button.request_location,
+      requestPoll: button.request_poll,
+      webApp: button.web_app,
+      requestUsers: button.request_users,
+      requestChat: button.request_chat,
+    });
+  };
+
+  const serializeReplyMarkup = (replyMarkup) => {
+    if (!replyMarkup) return null;
+    const inlineKeyboard = toArray(replyMarkup.inline_keyboard).map((row) =>
+      toArray(row).map(serializeInlineButton)
+    );
+    const keyboard = toArray(replyMarkup.keyboard).map((row) =>
+      toArray(row).map(serializeKeyboardButton)
+    );
+    const inlineButtonsFlat = inlineKeyboard.flat().filter(Boolean);
+    const keyboardButtonsFlat = keyboard.flat().filter(Boolean);
+
+    return {
+      hasInlineKeyboard: inlineButtonsFlat.length > 0,
+      hasKeyboard: keyboardButtonsFlat.length > 0,
+      inlineKeyboard,
+      keyboard,
+      inlineButtonsFlat,
+      keyboardButtonsFlat,
+      removeKeyboard: Boolean(replyMarkup.remove_keyboard),
+      forceReply: Boolean(replyMarkup.force_reply),
+      selective: Boolean(replyMarkup.selective),
+      oneTimeKeyboard: Boolean(replyMarkup.one_time_keyboard),
+      resizeKeyboard: Boolean(replyMarkup.resize_keyboard),
+      inputFieldPlaceholder: replyMarkup.input_field_placeholder || null,
+    };
+  };
+
+  const parseCommand = (messageText, forcedCommandName) => {
+    const text = (messageText || "").trim();
+    if (!text.startsWith("/")) {
+      return {
+        raw: text,
+        name: forcedCommandName || null,
+        args: [],
+        argsText: "",
+        hasBotMention: false,
+        botMention: null,
+      };
+    }
+
+    const [head = "", ...tail] = text.split(/\s+/);
+    const [nameFromMessage, botMention = null] = head.slice(1).split("@");
+
+    return {
+      raw: text,
+      name: forcedCommandName || nameFromMessage || null,
+      args: tail,
+      argsText: tail.join(" "),
+      hasBotMention: Boolean(botMention),
+      botMention,
+    };
+  };
+
+  const serializeMessage = (message) => {
+    if (!message) return null;
+
+    return pickDefined({
+      messageId: message.message_id,
+      messageThreadId: message.message_thread_id,
+      date: safeDate(message.date),
+      editDate: safeDate(message.edit_date),
+      text: message.text || message.caption || "",
+      caption: message.caption,
+      hasText: Boolean(message.text),
+      hasCaption: Boolean(message.caption),
+      entities: serializeEntities(message.entities),
+      captionEntities: serializeEntities(message.caption_entities),
+      from: serializeUser(message.from),
+      senderChat: serializeChat(message.sender_chat),
+      authorSignature: message.author_signature,
+      isAutomaticForward: message.is_automatic_forward,
+      hasProtectedContent: message.has_protected_content,
+      mediaGroupId: message.media_group_id,
+      connectedWebsite: message.connected_website,
+      replyToMessageId: message.reply_to_message?.message_id,
+      forwardFrom: serializeUser(message.forward_from),
+      forwardFromChat: serializeChat(message.forward_from_chat),
+      forwardDate: safeDate(message.forward_date),
+      viaBot: serializeUser(message.via_bot),
+      replyMarkup: serializeReplyMarkup(message.reply_markup),
+      photo: toArray(message.photo).map(serializeFileMeta),
+      video: serializeFileMeta(message.video),
+      videoNote: serializeFileMeta(message.video_note),
+      animation: serializeFileMeta(message.animation),
+      audio: serializeFileMeta(message.audio),
+      voice: serializeFileMeta(message.voice),
+      document: serializeFileMeta(message.document),
+      sticker: serializeFileMeta(message.sticker),
+      location: message.location
+        ? pickDefined({
+            latitude: message.location.latitude,
+            longitude: message.location.longitude,
+            horizontalAccuracy: message.location.horizontal_accuracy,
+            livePeriod: message.location.live_period,
+          })
+        : null,
+      contact: message.contact
+        ? pickDefined({
+            phoneNumber: message.contact.phone_number,
+            firstName: message.contact.first_name,
+            lastName: message.contact.last_name,
+            userId: message.contact.user_id,
+            vcard: message.contact.vcard,
+          })
+        : null,
+      poll: message.poll
+        ? pickDefined({
+            id: message.poll.id,
+            question: message.poll.question,
+            type: message.poll.type,
+            allowsMultipleAnswers: message.poll.allows_multiple_answers,
+            isClosed: message.poll.is_closed,
+          })
+        : null,
+    });
+  };
+
+  const serializeCallbackQuery = (callbackQuery) => {
+    if (!callbackQuery) return null;
+    return pickDefined({
+      id: callbackQuery.id,
+      chatInstance: callbackQuery.chat_instance,
+      from: serializeUser(callbackQuery.from),
+      data: callbackQuery.data,
+      gameShortName: callbackQuery.game_short_name,
+      inlineMessageId: callbackQuery.inline_message_id,
+      message: serializeMessage(callbackQuery.message),
+    });
+  };
+
+  const update = ctx.update || {};
+  const message =
+    ctx.message || ctx.editedMessage || ctx.channelPost || ctx.editedChannelPost || null;
+
+  const serializedMessage = serializeMessage(message);
+  const serializedCallbackQuery = serializeCallbackQuery(ctx.callbackQuery);
+
+  const inlineButtons =
+    serializedCallbackQuery?.message?.replyMarkup?.inlineButtonsFlat ||
+    serializedMessage?.replyMarkup?.inlineButtonsFlat ||
+    [];
+
+  const matchedInline = inlineButtons.find(
+    (button) => button.callbackData === serializedCallbackQuery?.data
+  );
+
+  return {
+    meta: {
+      updateId: update.update_id ?? null,
+      updateType: ctx.updateType ?? null,
+      receivedAt: new Date().toISOString(),
+      isEdited: Boolean(ctx.editedMessage || ctx.editedChannelPost),
+    },
+    chat: serializeChat(ctx.chat),
+    from: serializeUser(ctx.from),
+    message: serializedMessage,
+    callbackQuery: serializedCallbackQuery,
+    command: parseCommand(message?.text || "", options.commandName),
+    buttons: {
+      replyMarkup: serializedMessage?.replyMarkup || null,
+      pressed: serializedCallbackQuery?.data
+        ? {
+            source: "callback_query",
+            callbackData: serializedCallbackQuery.data,
+            matchedInlineButton: matchedInline || null,
+            pressedText: matchedInline?.text || null,
+            callbackQueryId: ctx.callbackQuery?.id || null,
+          }
+        : null,
+      hasAnyButton: Boolean(
+        serializedMessage?.replyMarkup?.hasInlineKeyboard ||
+          serializedMessage?.replyMarkup?.hasKeyboard ||
+          serializedCallbackQuery?.data
+      ),
+    },
+    rawUpdate: update,
+  };
+}
+
+module.exports = {
+  serializeTelegramUpdate,
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "telegram-bot-starter",
+  "version": "1.0.0",
+  "description": "Bot Telegram sederhana, plugin auto-register, serializer terpisah (Node.js)",
+  "main": "bot_telegram.js",
+  "scripts": {
+    "start": "node bot_telegram.js",
+    "check": "node --check bot_telegram.js && node --check lib/*.js && node --check plugins/*.js"
+  },
+  "keywords": [
+    "telegram",
+    "bot",
+    "nodejs",
+    "telegraf",
+    "plugin"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "telegraf": "^4.16.3"
+  }
+}

--- a/plugins/buttons.js
+++ b/plugins/buttons.js
@@ -1,0 +1,20 @@
+"use strict";
+
+module.exports = {
+  name: "buttons",
+  description: "Button singkat + demo auto edit pesan (edit:true)",
+  run: async ({ ctx }) => {
+    await ctx.sendMessage(
+      "Menu utama",
+      ["Lihat status", "status"],
+      ["Edit pesan ini", "edit_menu", { edit: true, text: "✅ Pesan sudah di-edit otomatis" }]
+    );
+
+    return ctx.sendPhoto(
+      "https://picsum.photos/300/200",
+      "Contoh media + button",
+      ["Foto OK", "foto_ok"],
+      ["Edit caption text", "edit_foto", { edit: true, text: "📸 Aksi dari tombol media" }]
+    );
+  },
+};

--- a/plugins/echo.js
+++ b/plugins/echo.js
@@ -1,0 +1,15 @@
+"use strict";
+
+module.exports = {
+  name: "echo",
+  description: "Ulangi teks kamu. Format: /echo <teks>",
+  run: ({ ctx, serialized }) => {
+    const text = serialized.command.argsText.trim();
+
+    if (!text) {
+      return ctx.reply("Format: /echo <teks>");
+    }
+
+    return ctx.reply(text);
+  },
+};

--- a/plugins/help.js
+++ b/plugins/help.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = {
+  name: "help",
+  description: "Menampilkan daftar semua command otomatis",
+  run: async ({ ctx, plugins }) => {
+    const list = plugins
+      .map((plugin) => `/${plugin.name} - ${plugin.description}`)
+      .join("\n");
+
+    await ctx.reply(
+      "Daftar command (auto dari folder plugins):\n" +
+        `${list}\n\n` +
+        "Tips: tambah file plugin baru di folder plugins/, command langsung terdaftar."
+    );
+  },
+};

--- a/plugins/id.js
+++ b/plugins/id.js
@@ -1,0 +1,23 @@
+"use strict";
+
+module.exports = {
+  name: "id",
+  description: "Lihat user/chat ID + ringkasan serialized context",
+  run: ({ ctx, serialized }) => {
+    const userId = serialized.from?.id ?? "-";
+    const chatId = serialized.chat?.id ?? "-";
+    const updateType = serialized.meta.updateType ?? "unknown";
+    const argsCount = serialized.command.args.length;
+    const hasAnyButton = serialized.buttons.hasAnyButton ? "ya" : "tidak";
+    const pressed = serialized.buttons.pressed?.callbackData || "-";
+
+    return ctx.reply(
+      `User ID: ${userId}\n` +
+        `Chat ID: ${chatId}\n` +
+        `Update Type: ${updateType}\n` +
+        `Args Count: ${argsCount}\n` +
+        `Ada Button: ${hasAnyButton}\n` +
+        `Button Ditekan: ${pressed}`
+    );
+  },
+};

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -1,0 +1,10 @@
+"use strict";
+
+/**
+ * Deprecated file.
+ *
+ * Registrasi command sekarang otomatis membaca semua file `plugins/*.js`
+ * (kecuali `index.js` dan file yang diawali `_`).
+ */
+
+module.exports = [];

--- a/plugins/ping.js
+++ b/plugins/ping.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+  name: "ping",
+  description: "Cek bot aktif",
+  run: ({ ctx }) => ctx.reply("pong ✅ Bot aktif."),
+};

--- a/plugins/start.js
+++ b/plugins/start.js
@@ -1,0 +1,19 @@
+"use strict";
+
+module.exports = {
+  name: "start",
+  description: "Sapaan awal dan contoh command",
+  run: async ({ ctx }) => {
+    const name = ctx.from?.first_name || "teman";
+
+    await ctx.reply(
+      `Halo ${name}! 👋\n\n` +
+        "Saya bot Telegram modular yang mudah kamu kembangkan.\n" +
+        "Coba command ini:\n" +
+        "• /help\n" +
+        "• /ping\n" +
+        "• /echo halo dunia\n" +
+        "• /id"
+    );
+  },
+};


### PR DESCRIPTION
### Motivation
- Create a minimal, modular Telegram bot starter that auto-registers commands from a `plugins/` folder.
- Provide a single serializer for incoming updates and a compact button format with global callback handling and optional auto-edit behavior.
- Include example plugins and docs to make the project immediately runnable and easy to extend.

### Description
- Add main entry `bot_telegram.js` which builds the `Telegraf` bot, registers plugins, exposes helper methods on `ctx` (`ctx.button`, `ctx.sendMessage`, `ctx.sendPhoto`, `ctx.editpesan`), and handles global `callback_query` with optional `edit:true` actions.
- Add `lib/button-format.js` implementing a button manager with `button`, `sendMessage`, `sendPhoto`, and `resolveAction` to map compact button definitions to callback data and optional edit actions.
- Add `lib/serialize.js` implementing `serializeTelegramUpdate(ctx, options)` which normalizes users, chats, messages, files, reply markup, commands, and callback queries into a consistent shape.
- Add `lib/plugin-loader.js` providing `loadPlugins` and `validatePlugin` to auto-load `plugins/*.js`, validate plugin shape, and detect duplicate command names.
- Add sample plugins in `plugins/` (`start`, `help`, `ping`, `echo`, `id`, `buttons`) demonstrating commands, button usage, media, and auto-edit behavior, plus a deprecated `plugins/index.js` placeholder.
- Add `README.md` with usage examples, and `.env.example` including `TELEGRAM_BOT_TOKEN` guidance, and `package.json` with `start` and `check` scripts.

### Testing
- No automated tests were executed as part of this change.
- A `check` npm script (`node --check bot_telegram.js && node --check lib/*.js && node --check plugins/*.js`) was added to perform syntax validation if desired.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad580922008323be279b469cfa63bd)